### PR TITLE
Provide strict Django requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-django<2
+django<1.10


### PR DESCRIPTION
Django v1.10 deprecates various features which were removed in v1.8 (https://docs.djangoproject.com/en/1.10/releases/1.10/#backwards-incompatible-1-10). These features break the current sample implementation.
This PR is meant is a quick workaround for these issues and to keep the sample running. In the future, the sample should be refactored to support django 1.10 and above.
